### PR TITLE
Use UTF-8 on Kconfig files.

### DIFF
--- a/kergen/depgen
+++ b/kergen/depgen
@@ -10,7 +10,7 @@ args = parser.parse_args()
 
 config = []
 if os.path.isfile('/usr/src/linux/.config'):
-    with open('/usr/src/linux/.config', 'r') as conf:
+    with open('/usr/src/linux/.config', 'r', encoding='utf-8') as conf:
         for line in conf:
             if line[:1] != '#':
                 config.append(line[7:-3])
@@ -19,7 +19,7 @@ if os.path.isfile('/usr/src/linux/.config'):
 def load_kconf_info(kconf_path):
     kconf_info_list = []
     if os.path.isfile('/usr/src/linux/' + kconf_path):
-        with open('/usr/src/linux/' + kconf_path, 'r') as kconf:
+        with open('/usr/src/linux/' + kconf_path, 'r', encoding='utf-8') as kconf:
             prepend_to_line = ''
             is_config_block = False
             is_menu = False

--- a/kergen/kergen-map
+++ b/kergen/kergen-map
@@ -153,7 +153,7 @@ def generate_device_kernel_options():
 
 def load_possible_filesystems(kpath):
     if os.path.isfile('/usr/src/linux/' + kpath):
-        with open('/usr/src/linux/' + kpath, 'r') as kconf:
+        with open('/usr/src/linux/' + kpath, 'r', encoding='utf-8') as kconf:
             kconf_options_list = []
 
             for line in kconf:


### PR DESCRIPTION
 "UnicodeDecodeError: 'ascii' codec can't decode byte" error on some patchsets.
